### PR TITLE
Make `OfBackend` inherit `Associated`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "backend"
-version = "0.1.4"
+version = "0.1.5"
 authors = [
     "bvssvni <bvssvni@gmail.com>",
 ]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,7 +26,7 @@ macro_rules! backend {
         }
 
         /// Used to get other types associated with backend.
-        pub trait OfBackend {
+        pub trait OfBackend: Associated {
             $(
             /// Associated type of backend.
             type $x;


### PR DESCRIPTION
This makes it possible to get the backend type from an `OfBackend`
constraint.
